### PR TITLE
docs: add memory bank and system info prompts

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,6 +24,51 @@
       },
       "problemMatcher": [],
       "type": "shell"
+    },
+    {
+      "command": "bash ${workspaceFolder}/scripts/memory-bank-init.sh",
+      "detail": "Initializes the memory bank structure. See memory-bank/prompts/memory-bank-init.prompt.md for details.",
+      "group": {
+        "isDefault": false,
+        "kind": "build"
+      },
+      "label": "Memory Bank Init",
+      "presentation": {
+        "panel": "shared",
+        "reveal": "always"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "command": "bash ${workspaceFolder}/scripts/memory-bank-validate.sh",
+      "detail": "Validates memory bank completeness and consistency. See memory-bank/prompts/memory-bank-validate.prompt.md for details.",
+      "group": {
+        "isDefault": false,
+        "kind": "build"
+      },
+      "label": "Memory Bank Validate",
+      "presentation": {
+        "panel": "shared",
+        "reveal": "always"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "command": "bash ${workspaceFolder}/scripts/system-info.sh",
+      "detail": "Displays basic system information and disk usage. See memory-bank/prompts/system-info.prompt.md for details.",
+      "group": {
+        "isDefault": false,
+        "kind": "build"
+      },
+      "label": "Show System Info",
+      "presentation": {
+        "panel": "shared",
+        "reveal": "always"
+      },
+      "problemMatcher": [],
+      "type": "shell"
     }
   ],
   "version": "2.0.0"

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,6 +17,7 @@ Memory Bank population and validation (August 2025)
 - Updated `memory-bank/chatmodes/README.md` to include the new chat mode with description
 - Synthesized knowledge from all devcontainer documentation files for expert guidance
 - Internal documentation files added to `memory-bank/instructions/` and referenced in Memory Bank core files for improved cross-linking and agent discoverability.
+- Added prompt files and VS Code tasks for memory bank initialization, validation, and system information.
 
 ### Last Session Summary
 
@@ -41,6 +42,7 @@ Memory Bank population and validation (August 2025)
 - Previously: Added `scripts/build-ts-project.sh`, `Build TypeScript Project` task, and `build-ts-project.prompt.md`
 - Previously: Updated scripts/README.md and prompts/README.md
 - Referenced internal instructions documentation in Memory Bank core files.
+- Added `memory-bank-init.prompt.md`, `memory-bank-validate.prompt.md`, and `system-info.prompt.md` with corresponding tasks.
 
 ## Next Steps
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -35,16 +35,19 @@ This section provides a high-level overview of the project's current state, incl
 
 - 2025-08-04: Added TypeScript build task, script, and prompt following 1:1:1 protocol (enables future development workflows)
 - 2025-08-04: Created DevContainers Expert chat mode with comprehensive knowledge synthesis from 9 documentation files
+- 2025-08-04: Added memory bank initialization, validation, and system info tasks with corresponding prompts
 
 ### Features Implemented
 
 - **TypeScript Build Task**: Fully implemented, documented, and protocol-compliant
 - **DevContainers Expert Chat Mode**: Comprehensive expert assistance for all dev container scenarios including setup, configuration, troubleshooting, and best practices
+- **Memory Bank Tools**: Prompt files and VS Code tasks for initializing, validating, and inspecting system information of the memory bank
 
 ### Technical Infrastructure
 
 - TypeScript build script (`scripts/build-ts-project.sh`) and VS Code task (`Build TypeScript Project`) in place
 - DevContainers Expert chat mode (`memory-bank/chatmodes/devcontainers-expert.chatmode.md`) with full knowledge base integration
+- Memory bank maintenance scripts and tasks (`memory-bank-init`, `memory-bank-validate`, `system-info`) documented with prompts
 
 ## Current Work
 

--- a/memory-bank/prompts/README.md
+++ b/memory-bank/prompts/README.md
@@ -46,9 +46,21 @@ This directory contains reusable prompt templates for common tasks, workflows, a
 
 **Purpose:** Provides a template for generating new `.prompt.md` files, including required front matter, file structure, content guidelines, and references for quality and consistency.
 
+### [memory-bank-init.prompt.md](../prompts/memory-bank-init.prompt.md)
+
+**Purpose:** Describes how to initialize the complete memory bank structure for new projects using the associated script and VS Code task.
+
+### [memory-bank-validate.prompt.md](../prompts/memory-bank-validate.prompt.md)
+
+**Purpose:** Explains how to validate memory bank completeness and consistency with the related script and VS Code task.
+
 ### [memory-update.prompt.md](../prompts/memory-update.prompt.md)
 
 **Purpose:** Ensures comprehensive memory bank updates, maintaining consistency across all files and providing complete context for AI agents. Includes review checklists and update workflows.
+
+### [system-info.prompt.md](../prompts/system-info.prompt.md)
+
+**Purpose:** Shows how to display basic system information and disk usage via the corresponding script and VS Code task.
 
 ---
 

--- a/memory-bank/prompts/memory-bank-init.prompt.md
+++ b/memory-bank/prompts/memory-bank-init.prompt.md
@@ -1,0 +1,15 @@
+---
+description: Initialize the complete memory bank structure for new projects using the memory-bank-init.sh script and VS Code task.
+---
+# Memory Bank Init Prompt
+
+This prompt explains how to create the full memory bank directory structure for a new project using the `memory-bank-init.sh` script.
+
+## Usage
+- Run the VS Code task: **Memory Bank Init**
+- Or execute the script directly: `bash scripts/memory-bank-init.sh [PROJECT_NAME]`
+
+## References
+- [Task-Script-Prompt 1:1:1 Pattern](../systemPatterns.md)
+- [Prompt Files Creation](../instructions/prompt-files.instructions.md)
+- [Instructions Files Usage](../instructions/instructions-files.instructions.md)

--- a/memory-bank/prompts/memory-bank-validate.prompt.md
+++ b/memory-bank/prompts/memory-bank-validate.prompt.md
@@ -1,0 +1,15 @@
+---
+description: Validate memory bank completeness and consistency using the memory-bank-validate.sh script and VS Code task.
+---
+# Memory Bank Validate Prompt
+
+This prompt describes how to verify that the memory bank contains all required files and cross-references.
+
+## Usage
+- Run the VS Code task: **Memory Bank Validate**
+- Or execute the script directly: `bash scripts/memory-bank-validate.sh [--fix] [--verbose]`
+
+## References
+- [Task-Script-Prompt 1:1:1 Pattern](../systemPatterns.md)
+- [Prompt Files Creation](../instructions/prompt-files.instructions.md)
+- [Instructions Files Usage](../instructions/instructions-files.instructions.md)

--- a/memory-bank/prompts/system-info.prompt.md
+++ b/memory-bank/prompts/system-info.prompt.md
@@ -1,0 +1,15 @@
+---
+description: Display basic system information and disk usage using the system-info.sh script and VS Code task.
+---
+# System Info Prompt
+
+This prompt outlines how to output basic system information and disk usage via the `system-info.sh` script.
+
+## Usage
+- Run the VS Code task: **Show System Info**
+- Or execute the script directly: `bash scripts/system-info.sh`
+
+## References
+- [Task-Script-Prompt 1:1:1 Pattern](../systemPatterns.md)
+- [Prompt Files Creation](../instructions/prompt-files.instructions.md)
+- [Instructions Files Usage](../instructions/instructions-files.instructions.md)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,7 +4,8 @@ All executable scripts must be referenced here with a description of their purpo
 
 ## Scripts in This Folder
 
-- `memory-bank-init.sh` - Initializes the complete memory bank structure for new projects
-- `memory-bank-validate.sh` - Validates memory bank completeness and consistency
-- `system-info.sh` - Displays basic system information and disk usage
-- `build-ts-project.sh` - Builds the TypeScript project in the src folder using tsc and src/tsconfig.json
+- `build-ts-project.sh` - Builds the TypeScript project in the src folder using tsc and src/tsconfig.json.
+- `get-current-datetime.sh` - Outputs the current local date/time for Québec City. See `../memory-bank/prompts/get-current-datetime.prompt.md`.
+- `memory-bank-init.sh` - Initializes the complete memory bank structure for new projects. See `../memory-bank/prompts/memory-bank-init.prompt.md`.
+- `memory-bank-validate.sh` - Validates memory bank completeness and consistency. See `../memory-bank/prompts/memory-bank-validate.prompt.md`.
+- `system-info.sh` - Displays basic system information and disk usage. See `../memory-bank/prompts/system-info.prompt.md`.


### PR DESCRIPTION
## Summary
- add prompts for initializing and validating the memory bank and for viewing system info
- expose new shell scripts as VS Code tasks with prompt references
- log new tools in scripts and prompts documentation and update active context

## Testing
- `bash scripts/memory-bank-validate.sh` *(fails: instructions/copilot.instructions.md missing)*

------
https://chatgpt.com/codex/tasks/task_e_68917ef355a48331bf862c9ae3b9ee4b