### PR TITLE
docs: add memory bank readmes

### DIFF
--- a/memory-bank/README.md
+++ b/memory-bank/README.md
@@ -1,0 +1,26 @@
+# Memory Bank
+
+Central hub for persistent project knowledge. It stores core context files, reusable assets, and references used by agents to maintain continuity.
+
+## Core Files
+
+- [projectbrief.md](./projectbrief.md) – high-level project identity, scope, and success criteria.
+- [productContext.md](./productContext.md) – product vision, user needs, and UX goals.
+- [activeContext.md](./activeContext.md) – current work focus, recent changes, and next steps.
+- [systemPatterns.md](./systemPatterns.md) – architecture, design patterns, and technical decisions.
+- [techContext.md](./techContext.md) – technology stack, environment, and constraints.
+- [progress.md](./progress.md) – project status, completed work, and remaining tasks.
+
+## Subdirectories
+
+- [docs/](./docs/README.md) – supplemental documentation and references.
+- [instructions/](./instructions/README.md) – operational guidelines and protocols.
+- [prompts/](./prompts/README.md) – reusable prompt templates.
+- [chatmodes/](./chatmodes/README.md) – predefined chat modes for structured interactions.
+
+## Related Instructions
+
+- [memory-bank-core.instructions.md](./instructions/memory-bank-core.instructions.md) – protocol for maintaining core files.
+- [memory-bank-docs.instructions.md](./instructions/memory-bank-docs.instructions.md) – complete guide to the memory bank system.
+
+> See [docs/README.md](./docs/README.md) for detailed documentation references.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,6 +13,7 @@ Memory Bank population and validation (August 2025)
 
 ### Recent Changes
 
+- Added `memory-bank/README.md` and `memory-bank/docs/README.md` with cross-links to core files and instructions
 - Created `devcontainers-expert.chatmode.md` - comprehensive expert chat mode for all dev container scenarios
 - Updated `memory-bank/chatmodes/README.md` to include the new chat mode with description
 - Synthesized knowledge from all devcontainer documentation files for expert guidance
@@ -20,14 +21,13 @@ Memory Bank population and validation (August 2025)
 
 ### Last Session Summary
 
-- Analyzed all devcontainer documentation files to understand comprehensive dev container ecosystem
-- Created specialized DevContainers Expert chat mode with deep knowledge of setup, configuration, troubleshooting, and best practices
-- Followed Memory Bank protocol and chatmode creation guidelines strictly
-- Updated chatmodes documentation to maintain synchronization
-- Began referencing internal instructions documentation in all relevant Memory Bank files.
+- Created `memory-bank/README.md` summarizing core files and subdirectories.
+- Added `memory-bank/docs/README.md` describing available documentation references.
+- Cross-linked new READMEs with instructions and ran validation (missing `instructions/copilot.instructions.md`).
 
 ### Recent Decisions
 
+- Introduced READMEs for memory bank root and docs to improve navigation and cohesion.
 - Created DevContainers Expert chat mode to provide specialized knowledge for all dev container scenarios
 - Synthesized comprehensive knowledge from 9 devcontainer documentation files into actionable expert guidance
 - Prioritized comprehensive coverage over simplified approaches for maximum utility
@@ -36,6 +36,7 @@ Memory Bank population and validation (August 2025)
 
 ### Code Changes
 
+- Added `memory-bank/README.md` and `memory-bank/docs/README.md` summarizing structure and references.
 - Added `memory-bank/chatmodes/devcontainers-expert.chatmode.md` - comprehensive expert chat mode
 - Updated `memory-bank/chatmodes/README.md` to include the new chat mode
 - Previously: Added `scripts/build-ts-project.sh`, `Build TypeScript Project` task, and `build-ts-project.prompt.md`

--- a/memory-bank/docs/README.md
+++ b/memory-bank/docs/README.md
@@ -1,0 +1,21 @@
+# Documentation References
+
+Reference materials to support workspace operations, tooling, and patterns.
+
+## Available Documents
+
+- [chat-modes.md](./chat-modes.md) – overview of VS Code chat modes and how to define custom modes.
+- [docker-tasks-reference.md](./docker-tasks-reference.md) – configuration reference for Docker build and run tasks via the Container Tools extension.
+- [task-provider.md](./task-provider.md) – guide to implementing VS Code task providers.
+- [tasks.md](./tasks.md) – comprehensive guide to defining and running tasks in VS Code.
+- [tasks-appendix.md](./tasks-appendix.md) – schema reference for `tasks.json` and related details.
+- [variables-reference.md](./variables-reference.md) – variable substitution reference for tasks and launch configurations.
+- [devcontainers/](./devcontainers) – curated documentation set covering Dev Container concepts, CLI, tips, and tutorials.
+- [LICENSE](./LICENSE) – licensing information for documentation sources.
+
+## Related Instructions
+
+- [memory-bank-docs.instructions.md](../instructions/memory-bank-docs.instructions.md) – setup and best practices for the memory bank.
+- [instructions directory](../instructions/README.md) – full list of workspace instructions.
+
+> Return to the [Memory Bank overview](../README.md) for context on core files and directories.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -33,11 +33,13 @@ This section provides a high-level overview of the project's current state, incl
 
 ### Major Milestones Achieved
 
+- 2025-08-05: Added memory-bank/README.md and memory-bank/docs/README.md summarizing structure and documentation references
 - 2025-08-04: Added TypeScript build task, script, and prompt following 1:1:1 protocol (enables future development workflows)
 - 2025-08-04: Created DevContainers Expert chat mode with comprehensive knowledge synthesis from 9 documentation files
 
 ### Features Implemented
 
+- **Memory Bank READMEs**: Root and docs summaries cross-linked with instructions
 - **TypeScript Build Task**: Fully implemented, documented, and protocol-compliant
 - **DevContainers Expert Chat Mode**: Comprehensive expert assistance for all dev container scenarios including setup, configuration, troubleshooting, and best practices
 
@@ -56,7 +58,7 @@ This section provides a high-level overview of the project's current state, incl
 
 ### Recent Sessions Summary
 
-- **Last Session**: [Date - key accomplishments and decisions]
+- **Last Session**: 2025-08-05 - Created memory-bank README files and ran validation (missing instructions/copilot.instructions.md)
 - **Previous Session**: [Date - key accomplishments and decisions]
 - **Session Before**: [Date - key accomplishments and decisions]
 


### PR DESCRIPTION
## Summary
- document core memory-bank structure and subdirectories with links
- add documentation reference index and cross-link to instructions
- record new readmes in active context and progress logs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `./scripts/memory-bank-validate.sh` *(fails: instructions/copilot.instructions.md missing)*

------
https://chatgpt.com/codex/tasks/task_e_68917ef50bd48331a771c14268b164ba