### PR TITLE
docs: use relative paths in memory bank

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -3,7 +3,7 @@
 ## Current Work Focus
 
 **Primary Objective:**
-Meta Project Maintenance Mode — synchronize and populate all Memory Bank core files with real, project-specific information. Ensure all internal documentation (see `memory-bank/instructions/`) is referenced and integrated into the Memory Bank for discoverability and operational clarity.
+Meta Project Maintenance Mode — synchronize and populate all Memory Bank core files with real, project-specific information. Ensure all internal documentation (see `instructions/`) is referenced and integrated into the Memory Bank for discoverability and operational clarity.
 
 **Current Phase:**
 Meta-maintenance and documentation synchronization
@@ -14,9 +14,9 @@ Memory Bank population and validation (August 2025)
 ### Recent Changes
 
 - Created `devcontainers-expert.chatmode.md` - comprehensive expert chat mode for all dev container scenarios
-- Updated `memory-bank/chatmodes/README.md` to include the new chat mode with description
+- Updated `chatmodes/README.md` to include the new chat mode with description
 - Synthesized knowledge from all devcontainer documentation files for expert guidance
-- Internal documentation files added to `memory-bank/instructions/` and referenced in Memory Bank core files for improved cross-linking and agent discoverability.
+- Internal documentation files added to `instructions/` and referenced in Memory Bank core files for improved cross-linking and agent discoverability.
 
 ### Last Session Summary
 
@@ -32,12 +32,12 @@ Memory Bank population and validation (August 2025)
 - Synthesized comprehensive knowledge from 9 devcontainer documentation files into actionable expert guidance
 - Prioritized comprehensive coverage over simplified approaches for maximum utility
 - Followed strict Memory Bank protocols and chatmode creation guidelines
-- Decided to reference and integrate all internal documentation in `memory-bank/instructions/` for agent context and discoverability.
+- Decided to reference and integrate all internal documentation in `instructions/` for agent context and discoverability.
 
 ### Code Changes
 
-- Added `memory-bank/chatmodes/devcontainers-expert.chatmode.md` - comprehensive expert chat mode
-- Updated `memory-bank/chatmodes/README.md` to include the new chat mode
+- Added `chatmodes/devcontainers-expert.chatmode.md` - comprehensive expert chat mode
+- Updated `chatmodes/README.md` to include the new chat mode
 - Previously: Added `scripts/build-ts-project.sh`, `Build TypeScript Project` task, and `build-ts-project.prompt.md`
 - Previously: Updated scripts/README.md and prompts/README.md
 - Referenced internal instructions documentation in Memory Bank core files.
@@ -49,13 +49,13 @@ Memory Bank population and validation (August 2025)
 1. Populate `projectbrief.md` with meta project identity, vision, and goals
 2. Update `productContext.md` with product vision and user experience context
 3. Fill in `systemPatterns.md`, `techContext.md`, and `progress.md` with real project data
-4. Ensure all internal documentation in `memory-bank/instructions/` is referenced in the Memory Bank and cross-linked where relevant.
+4. Ensure all internal documentation in `instructions/` is referenced in the Memory Bank and cross-linked where relevant.
 
 ### Upcoming Priorities (Next 2-3 Sessions)
 
 - Complete Memory Bank population for all core files
 - Validate cross-references and consistency, especially with internal documentation and instructions
-- Establish a workflow for ongoing Memory Bank updates, including regular review of `memory-bank/instructions/` and related documentation
+- Establish a workflow for ongoing Memory Bank updates, including regular review of `instructions/` and related documentation
 
 ### Pending Dependencies
 
@@ -79,14 +79,14 @@ Memory Bank population and validation (August 2025)
 
 ### Current Mental Model
 
-The project is in a meta-maintenance phase. All Memory Bank files exist but are templates. The immediate goal is to populate them with real, actionable project data to enable effective autonomous operation and cross-agent coordination. Internal documentation in `memory-bank/instructions/` is now referenced and should be used for all protocol, process, and operational guidance.
+The project is in a meta-maintenance phase. All Memory Bank files exist but are templates. The immediate goal is to populate them with real, actionable project data to enable effective autonomous operation and cross-agent coordination. Internal documentation in `instructions/` is now referenced and should be used for all protocol, process, and operational guidance.
 
 ### Critical Patterns to Remember
 
 - Always update Memory Bank after significant changes
 - Prioritize `activeContext.md` for current state and next steps
 - Maintain cross-file consistency and references
-- Reference and update internal documentation in `memory-bank/instructions/` as part of all Memory Bank updates
+- Reference and update internal documentation in `instructions/` as part of all Memory Bank updates
 
 ### Learnings and Insights
 

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -154,25 +154,25 @@ This section defines the product's vision, including its purpose, target users, 
 - **MANDATORY**: All features must align with defined user journeys
 - **MANDATORY**: User experience principles must guide all design decisions
 - **MANDATORY**: Accessibility requirements are non-negotiable
-- **MANDATORY**: Reference internal documentation and instructions in `memory-bank/instructions/` for user experience, accessibility, and product requirements.
+- **MANDATORY**: Reference internal documentation and instructions in `instructions/` for user experience, accessibility, and product requirements.
 
 ### Product Vision Compliance
 
 - **MANDATORY**: Every feature must contribute to the core value proposition
 - **MANDATORY**: User research insights must inform development priorities
 - **MANDATORY**: Business constraints must be respected in all recommendations
-- **MANDATORY**: Consult `memory-bank/instructions/` for product vision, user research, and business context documentation.
+- **MANDATORY**: Consult `instructions/` for product vision, user research, and business context documentation.
 
 ### Quality Assurance
 
 - **MANDATORY**: User acceptance criteria must be met before feature completion
 - **MANDATORY**: Performance standards must be validated during development
 - **MANDATORY**: Content quality standards must be maintained across all outputs
-- **MANDATORY**: Reference internal documentation in `memory-bank/instructions/` for quality standards, acceptance criteria, and performance benchmarks.
+- **MANDATORY**: Reference internal documentation in `instructions/` for quality standards, acceptance criteria, and performance benchmarks.
 
 ### Cross-Agent Coordination
 
 - This file defines the product requirements all AI agents must respect
 - Feature decisions must align with documented user needs and business goals
 - Deviations from product vision require explicit justification and stakeholder approval
-- Internal documentation in `memory-bank/instructions/` supplements this file and should be referenced for detailed product and user experience requirements.
+- Internal documentation in `instructions/` supplements this file and should be referenced for detailed product and user experience requirements.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -35,6 +35,7 @@ This section provides a high-level overview of the project's current state, incl
 
 - 2025-08-04: Added TypeScript build task, script, and prompt following 1:1:1 protocol (enables future development workflows)
 - 2025-08-04: Created DevContainers Expert chat mode with comprehensive knowledge synthesis from 9 documentation files
+- 2025-08-05: Converted Memory Bank references to relative paths and validated link integrity
 
 ### Features Implemented
 
@@ -44,7 +45,7 @@ This section provides a high-level overview of the project's current state, incl
 ### Technical Infrastructure
 
 - TypeScript build script (`scripts/build-ts-project.sh`) and VS Code task (`Build TypeScript Project`) in place
-- DevContainers Expert chat mode (`memory-bank/chatmodes/devcontainers-expert.chatmode.md`) with full knowledge base integration
+- DevContainers Expert chat mode (`chatmodes/devcontainers-expert.chatmode.md`) with full knowledge base integration
 
 ## Current Work
 
@@ -173,18 +174,18 @@ This section provides a high-level overview of the project's current state, incl
 - **MANDATORY**: Update this file after every significant work session
 - **MANDATORY**: Document all completed work with specific outcomes
 - **MANDATORY**: Record new issues and blockers immediately when discovered
-- **MANDATORY**: Reference internal documentation and instructions in `memory-bank/instructions/` for progress tracking protocols, update procedures, and documentation standards.
+- **MANDATORY**: Reference internal documentation and instructions in `instructions/` for progress tracking protocols, update procedures, and documentation standards.
 
 ### Status Reporting
 
 - **MANDATORY**: Maintain accurate completion percentages for each project phase
 - **MANDATORY**: Update current work sections before starting new tasks
 - **MANDATORY**: Document lessons learned while they are fresh
-- **MANDATORY**: Consult `memory-bank/instructions/` for reporting standards, documentation templates, and update workflows.
+- **MANDATORY**: Consult `instructions/` for reporting standards, documentation templates, and update workflows.
 
 ### Cross-Agent Coordination
 
 - This file provides the authoritative project status for all AI agents
 - All agents must sync progress updates to maintain consistency
 - Conflicting progress reports indicate need for reconciliation and clarification
-- Internal documentation in `memory-bank/instructions/` supplements this file and should be referenced for all progress tracking and reporting procedures.
+- Internal documentation in `instructions/` supplements this file and should be referenced for all progress tracking and reporting procedures.

--- a/memory-bank/projectbrief.md
+++ b/memory-bank/projectbrief.md
@@ -93,11 +93,11 @@ This section defines the project's identity, including its name, vision, and mis
 - **MANDATORY**: All AI agents MUST read this file completely before any project work
 - **MANDATORY**: Any changes to project scope the AI agent (you) MUST update this file immediately
 - **MANDATORY**: Reference this file when making architectural decisions
-- **MANDATORY**: Reference and consult internal documentation and instructions in `memory-bank/instructions/` for project protocols, conventions, and operational guidance.
+- **MANDATORY**: Reference and consult internal documentation and instructions in `instructions/` for project protocols, conventions, and operational guidance.
 
 ### Cross-Agent Coordination
 
 - This file serves as the authoritative project definition for all AI tools
 - Updates require full memory bank synchronization
 - Conflicts with this brief indicate need for clarification or scope adjustment
-- Internal documentation in `memory-bank/instructions/` supplements this brief and should be referenced for detailed instructions, conventions, and process documentation.
+- Internal documentation in `instructions/` supplements this brief and should be referenced for detailed instructions, conventions, and process documentation.

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -14,7 +14,7 @@ This section provides an overview of the system architecture, including key comp
 
 ## Internal Documentation and Instructions
 
-All system patterns, conventions, and technical protocols are further detailed in the internal documentation located in `memory-bank/instructions/`. This directory contains:
+All system patterns, conventions, and technical protocols are further detailed in the internal documentation located in `instructions/`. This directory contains:
 
 - Protocols for chatmode creation, prompt files, and instructions files
 - Prettier and formatting configuration
@@ -164,16 +164,16 @@ Establish a 1:1:1 mapping between VS Code tasks, scripts, and prompt documentati
 
 - Clearly defined in `.vscode/tasks.json`
 - Backed by a dedicated script in the `scripts/` folder
-- Documented with a corresponding `.prompt.md` file in `memory-bank/prompts/`
+- Documented with a corresponding `.prompt.md` file in `prompts/`
 
 ## Procedure
 
 1. **Create a Script**: Place a script in `scripts/` that performs the desired operation, using best practices for portability and clarity.
 2. **Define a Task**: Add a VS Code task in `.vscode/tasks.json` referencing the script, with a descriptive label and details for autonomous use.
-3. **Document with a Prompt**: Write a `.prompt.md` file in `memory-bank/prompts/` explaining the task, script, and usage instructions for AI agents.
+3. **Document with a Prompt**: Write a `.prompt.md` file in `prompts/` explaining the task, script, and usage instructions for AI agents.
 4. **Maintain 1:1:1 Mapping**: Ensure each task has exactly one script and one prompt, and vice versa, for traceability and maintainability.
 5. **Update Memory Bank**: After adding or modifying a task, update the memory bank to record the new mapping and procedure.
-6. **Reference Internal Instructions**: For all new patterns, protocols, or conventions, update or create a file in `memory-bank/instructions/` and reference it here and in other relevant Memory Bank files.
+6. **Reference Internal Instructions**: For all new patterns, protocols, or conventions, update or create a file in `instructions/` and reference it here and in other relevant Memory Bank files.
 
 ## Benefits
 
@@ -203,4 +203,4 @@ This pattern should be followed for all new automated tasks. When initializing a
 - This file defines the technical foundation all AI agents must respect
 - Architecture changes require consensus and full documentation
 - Pattern violations indicate need for system redesign consideration
-- Internal documentation in `memory-bank/instructions/` supplements this file and must be referenced for all technical protocols, conventions, and system patterns.
+- Internal documentation in `instructions/` supplements this file and must be referenced for all technical protocols, conventions, and system patterns.


### PR DESCRIPTION
## Summary
- update memory bank markdown files to use relative links for instructions, chatmodes, and prompts
- log relative-link migration in progress log

## Testing
- `bash scripts/memory-bank-validate.sh`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68917ef6cc508331b94cf5905dda5207