### PR TITLE
chore(memory-bank): document module initialization task placeholders

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -56,6 +56,7 @@ Memory Bank population and validation (August 2025)
 - Complete Memory Bank population for all core files
 - Validate cross-references and consistency, especially with internal documentation and instructions
 - Establish a workflow for ongoing Memory Bank updates, including regular review of `memory-bank/instructions/` and related documentation
+- Draft module initialization tasks as placeholders to activate when the module is initialized; see [initialization prompt](../prompts/initialization.prompt.md) and internal [tasks guide](../docs/tasks.md)
 
 ### Pending Dependencies
 

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -147,6 +147,10 @@ This section defines the product's vision, including its purpose, target users, 
 - **Completeness**: [Information completeness standards]
 - **Consistency**: [Cross-platform and cross-feature consistency]
 
+## Module Initialization Tasks (Placeholder)
+
+- Module initialization tasks will be activated once the module is initialized. For preparation details, refer to the [initialization prompt](../prompts/initialization.prompt.md) and the internal [tasks guide](../docs/tasks.md).
+
 ## AI Agent Instructions
 
 ### User-Centric Development

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -73,6 +73,7 @@ This section provides a high-level overview of the project's current state, incl
 - [Priority 1 - scope and urgency]
 - [Priority 2 - scope and urgency]
 - [Priority 3 - scope and urgency]
+- Prepare module initialization tasks as placeholders to activate when the module is initialized; see [initialization prompt](../prompts/initialization.prompt.md) and [tasks guide](../docs/tasks.md)
 
 ### Medium-term Goals (Next 1-2 Weeks)
 

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -192,6 +192,10 @@ This pattern should be followed for all new automated tasks. When initializing a
 - **MANDATORY**: Deviations require explicit justification and documentation
 - **MANDATORY**: New patterns must be documented here immediately
 
+## Module Initialization Tasks (Placeholder)
+
+- Module initialization tasks are prepared but inactive until the module is initialized. Refer to the [initialization prompt](../prompts/initialization.prompt.md) and the [tasks guide](../docs/tasks.md) for activation details.
+
 ### Architecture Enforcement
 
 - **MANDATORY**: Verify component relationships before modifications

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -170,6 +170,10 @@ VARIABLE_3=description_and_example_value
 - **Configuration Sync**: [How tool configurations stay aligned]
 - **Conflict Resolution**: [How to handle conflicting tool requirements]
 
+## Module Initialization Tasks (Placeholder)
+
+- Module initialization tasks are outlined but inactive until the module is initialized. Refer to the [initialization prompt](../prompts/initialization.prompt.md) and the internal [tasks guide](../docs/tasks.md) for activation details.
+
 ## AI Agent Instructions
 
 ### Environment Compliance


### PR DESCRIPTION
## Summary
- note module initialization placeholder tasks in Active Context with links to initialization prompt and tasks guide
- add module initialization placeholder sections to Product, System, and Tech contexts
- record placeholder module initialization tasks in project progress log

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68917f0110b88331a507a542b5e8ab66