### PR TITLE
feat: add memory bank workflow script and task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,6 +24,16 @@
       },
       "problemMatcher": [],
       "type": "shell"
+    },
+    {
+      "command": "bash ${workspaceFolder}/scripts/memory-bank-run.sh",
+      "detail": "Initializes and validates the memory bank using the memory-bank-run.sh script.",
+      "group": {
+        "isDefault": false,
+        "kind": "build"
+      },
+      "label": "Run Memory Bank Workflow",
+      "type": "shell"
     }
   ],
   "version": "2.0.0"

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,6 +17,7 @@ Memory Bank population and validation (August 2025)
 - Updated `memory-bank/chatmodes/README.md` to include the new chat mode with description
 - Synthesized knowledge from all devcontainer documentation files for expert guidance
 - Internal documentation files added to `memory-bank/instructions/` and referenced in Memory Bank core files for improved cross-linking and agent discoverability.
+- Added composite memory bank workflow: `scripts/memory-bank-run.sh`, `Run Memory Bank Workflow` task, and `memory-bank-run.prompt.md` for sequential initialization and validation
 
 ### Last Session Summary
 
@@ -41,6 +42,7 @@ Memory Bank population and validation (August 2025)
 - Previously: Added `scripts/build-ts-project.sh`, `Build TypeScript Project` task, and `build-ts-project.prompt.md`
 - Previously: Updated scripts/README.md and prompts/README.md
 - Referenced internal instructions documentation in Memory Bank core files.
+- Added `scripts/memory-bank-run.sh`, `Run Memory Bank Workflow` task, and `memory-bank-run.prompt.md` to automate memory bank initialization and validation
 
 ## Next Steps
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -35,16 +35,19 @@ This section provides a high-level overview of the project's current state, incl
 
 - 2025-08-04: Added TypeScript build task, script, and prompt following 1:1:1 protocol (enables future development workflows)
 - 2025-08-04: Created DevContainers Expert chat mode with comprehensive knowledge synthesis from 9 documentation files
+- 2025-08-05: Added Memory Bank workflow script, VS Code task, and prompt for combined initialization and validation
 
 ### Features Implemented
 
 - **TypeScript Build Task**: Fully implemented, documented, and protocol-compliant
 - **DevContainers Expert Chat Mode**: Comprehensive expert assistance for all dev container scenarios including setup, configuration, troubleshooting, and best practices
+- **Memory Bank Workflow Task**: Runs initialization and validation sequentially via composite script, task, and prompt
 
 ### Technical Infrastructure
 
 - TypeScript build script (`scripts/build-ts-project.sh`) and VS Code task (`Build TypeScript Project`) in place
 - DevContainers Expert chat mode (`memory-bank/chatmodes/devcontainers-expert.chatmode.md`) with full knowledge base integration
+- Memory bank workflow automation (`scripts/memory-bank-run.sh`, `Run Memory Bank Workflow` task, `memory-bank-run.prompt.md`)
 
 ## Current Work
 

--- a/memory-bank/prompts/README.md
+++ b/memory-bank/prompts/README.md
@@ -30,6 +30,10 @@ This directory contains reusable prompt templates for common tasks, workflows, a
 
 **Purpose:** Explains how to use the autonomous AI agent task for retrieving the current local date and time in Québec City, referencing the related script and VS Code task.
 
+### [memory-bank-run.prompt.md](../prompts/memory-bank-run.prompt.md)
+
+**Purpose:** Runs memory bank initialization and validation sequentially via the composite script and VS Code task.
+
 ### [gitmoji-complete-list.prompt.md](../prompts/gitmoji-complete-list.prompt.md)
 
 **Purpose:** Contains a complete list of gitmoji for conventional commits, with selection guidelines to help choose the most appropriate emoji for each commit type.

--- a/memory-bank/prompts/memory-bank-run.prompt.md
+++ b/memory-bank/prompts/memory-bank-run.prompt.md
@@ -1,0 +1,20 @@
+---
+mode: 'agent'
+model: GPT-4.1
+tools: ['shell']
+description: Runs memory bank initialization and validation sequentially using the memory-bank-run.sh script.
+---
+# Memory Bank Workflow Prompt
+
+Execute the full memory bank workflow to initialize then validate the memory bank structure.
+
+## Usage
+- Run the VS Code task **Run Memory Bank Workflow**
+- Or execute the script directly: `bash scripts/memory-bank-run.sh`
+
+## References
+- [memory-bank-run.sh](../../scripts/memory-bank-run.sh)
+- [memory-bank-init.sh](../../scripts/memory-bank-init.sh)
+- [memory-bank-validate.sh](../../scripts/memory-bank-validate.sh)
+- [Task-Script-Prompt 1:1:1 Pattern](../systemPatterns.md)
+- [Prompt Files Creation](../instructions/prompt-files.instructions.md)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,5 +6,7 @@ All executable scripts must be referenced here with a description of their purpo
 
 - `memory-bank-init.sh` - Initializes the complete memory bank structure for new projects
 - `memory-bank-validate.sh` - Validates memory bank completeness and consistency
+- `memory-bank-run.sh` - Initializes then validates the memory bank sequentially
 - `system-info.sh` - Displays basic system information and disk usage
 - `build-ts-project.sh` - Builds the TypeScript project in the src folder using tsc and src/tsconfig.json
+- `get-current-datetime.sh` - Outputs the current local date/time for Québec City (America/Toronto timezone)

--- a/scripts/memory-bank-run.sh
+++ b/scripts/memory-bank-run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Memory Bank Workflow Script
+# Runs initialization and validation sequentially
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/memory-bank-init.sh"
+"$SCRIPT_DIR/memory-bank-validate.sh"


### PR DESCRIPTION
## Summary
- add `memory-bank-run.sh` to initialize then validate the memory bank
- wire "Run Memory Bank Workflow" task to the composite script
- document the workflow with a dedicated prompt and README updates

## Testing
- `printf '\n' | bash scripts/memory-bank-run.sh` *(fails: instructions/copilot.instructions.md missing)*

------
https://chatgpt.com/codex/tasks/task_e_68917f040c7083318808e289ebf6de7d