### PR TITLE
feat: add base tsconfig for TypeScript builds

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,6 +17,7 @@ Memory Bank population and validation (August 2025)
 - Updated `memory-bank/chatmodes/README.md` to include the new chat mode with description
 - Synthesized knowledge from all devcontainer documentation files for expert guidance
 - Internal documentation files added to `memory-bank/instructions/` and referenced in Memory Bank core files for improved cross-linking and agent discoverability.
+- Added base `tsconfig.json` and updated TypeScript build prompt and documentation
 
 ### Last Session Summary
 
@@ -25,6 +26,7 @@ Memory Bank population and validation (August 2025)
 - Followed Memory Bank protocol and chatmode creation guidelines strictly
 - Updated chatmodes documentation to maintain synchronization
 - Began referencing internal instructions documentation in all relevant Memory Bank files.
+- Established baseline TypeScript configuration and aligned build documentation
 
 ### Recent Decisions
 
@@ -41,6 +43,7 @@ Memory Bank population and validation (August 2025)
 - Previously: Added `scripts/build-ts-project.sh`, `Build TypeScript Project` task, and `build-ts-project.prompt.md`
 - Previously: Updated scripts/README.md and prompts/README.md
 - Referenced internal instructions documentation in Memory Bank core files.
+- Added root `tsconfig.json` and updated `scripts/README.md` and `build-ts-project.prompt.md`
 
 ## Next Steps
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -35,6 +35,7 @@ This section provides a high-level overview of the project's current state, incl
 
 - 2025-08-04: Added TypeScript build task, script, and prompt following 1:1:1 protocol (enables future development workflows)
 - 2025-08-04: Created DevContainers Expert chat mode with comprehensive knowledge synthesis from 9 documentation files
+- 2025-08-05: Added base `tsconfig.json` and aligned build documentation
 
 ### Features Implemented
 
@@ -45,6 +46,7 @@ This section provides a high-level overview of the project's current state, incl
 
 - TypeScript build script (`scripts/build-ts-project.sh`) and VS Code task (`Build TypeScript Project`) in place
 - DevContainers Expert chat mode (`memory-bank/chatmodes/devcontainers-expert.chatmode.md`) with full knowledge base integration
+- Base TypeScript configuration (`tsconfig.json`) established in repository root
 
 ## Current Work
 

--- a/memory-bank/prompts/build-ts-project.prompt.md
+++ b/memory-bank/prompts/build-ts-project.prompt.md
@@ -3,7 +3,7 @@ description: Prompt for building the TypeScript project in the src folder using 
 ---
 # Build TypeScript Project Prompt
 
-This prompt describes the process for building the TypeScript project located in the `src` folder. The build is performed using the `build-ts-project.sh` script, which runs the TypeScript compiler (`tsc`) with the configuration in `src/tsconfig.json`.
+This prompt describes the process for building the TypeScript project located in the `src` folder. The build is performed using the `build-ts-project.sh` script, which runs the TypeScript compiler (`tsc`) with the configuration in the repository root `tsconfig.json`.
 
 ## Usage
 - Run the VS Code task: **Build TypeScript Project**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,4 +7,4 @@ All executable scripts must be referenced here with a description of their purpo
 - `memory-bank-init.sh` - Initializes the complete memory bank structure for new projects
 - `memory-bank-validate.sh` - Validates memory bank completeness and consistency
 - `system-info.sh` - Displays basic system information and disk usage
-- `build-ts-project.sh` - Builds the TypeScript project in the src folder using tsc and src/tsconfig.json
+- `build-ts-project.sh` - Builds the TypeScript project in the src folder using tsc and the root tsconfig.json

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- add base `tsconfig.json` targeting `src` and outputting to `dist`
- document build script to use root config and update build prompt
- record new configuration in memory bank

## Testing
- `bash scripts/build-ts-project.sh`

------
https://chatgpt.com/codex/tasks/task_e_68917f0c29648331bf7327e455f12c8b