### PR TITLE
chore(memory-bank): reference system patterns in datetime prompt

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,6 +17,7 @@ Memory Bank population and validation (August 2025)
 - Updated `memory-bank/chatmodes/README.md` to include the new chat mode with description
 - Synthesized knowledge from all devcontainer documentation files for expert guidance
 - Internal documentation files added to `memory-bank/instructions/` and referenced in Memory Bank core files for improved cross-linking and agent discoverability.
+- Updated `memory-bank/prompts/get-current-datetime.prompt.md` with references and a link to `systemPatterns.md` reinforcing the 1:1:1 task-script-prompt pattern.
 
 ### Last Session Summary
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -35,6 +35,7 @@ This section provides a high-level overview of the project's current state, incl
 
 - 2025-08-04: Added TypeScript build task, script, and prompt following 1:1:1 protocol (enables future development workflows)
 - 2025-08-04: Created DevContainers Expert chat mode with comprehensive knowledge synthesis from 9 documentation files
+- 2025-08-05: Updated get-current-datetime prompt with references and systemPatterns link reinforcing 1:1:1 mapping
 
 ### Features Implemented
 

--- a/memory-bank/prompts/get-current-datetime.prompt.md
+++ b/memory-bank/prompts/get-current-datetime.prompt.md
@@ -26,7 +26,7 @@ This prompt describes how to use the autonomous AI agent task for retrieving the
 ## Best Practices
 - Always use the provided task for consistent results.
 - Do not modify the script or task label without updating this prompt.
-- Maintain 1:1:1 mapping: **task ↔ script ↔ prompt** for clarity and maintainability.
+- Maintain 1:1:1 mapping: **task ↔ script ↔ prompt** for clarity and maintainability. See [systemPatterns.md](../systemPatterns.md) for details.
 
 ---
 
@@ -48,4 +48,9 @@ The active terminal's last run command
 terminalSelection: terminalSelection (Built-In)
 The active terminal's selection
 
-_Last updated: 2025-08-04_
+## References
+- [Task-Script-Prompt 1:1:1 Pattern](../systemPatterns.md)
+- [Prompt Files Creation](../instructions/prompt-files.instructions.md)
+- [Instructions Files Usage](../instructions/instructions-files.instructions.md)
+
+_Last updated: 2025-08-05_


### PR DESCRIPTION
## Summary
- link task-script-prompt pattern in get-current-datetime prompt
- add references section and instruction links
- log prompt update in active context and progress

## Testing
- `bash scripts/get-current-datetime.sh`


------
https://chatgpt.com/codex/tasks/task_e_68917f113df08331a3033b861e795b31