### PR TITLE
docs: add Memory Bank overview

### DIFF
--- a/memory-bank/README.md
+++ b/memory-bank/README.md
@@ -1,0 +1,18 @@
+# Memory Bank
+
+Central repository of project context and documentation used by AI agents. Each core file captures a different aspect of the project's state:
+
+- **[projectbrief.md](./projectbrief.md)** – Defines project identity, vision, scope, and success criteria.
+- **[productContext.md](./productContext.md)** – Describes why the product exists, the problems it solves, and user experience goals.
+- **[systemPatterns.md](./systemPatterns.md)** – Records system architecture, design patterns, and key technical decisions.
+- **[techContext.md](./techContext.md)** – Lists technology stack, development setup, and technical constraints.
+- **[activeContext.md](./activeContext.md)** – Tracks current work focus, recent changes, and next steps.
+- **[progress.md](./progress.md)** – Logs completed work, current status, and remaining objectives.
+
+## Subdirectories
+
+- [prompts/](./prompts/) – Prompt files linked to VS Code tasks and scripts.
+- [instructions/](./instructions/) – Internal documentation and operational guidelines.
+- [chatmodes/](./chatmodes/) – Chat mode definitions for specialized interactions.
+- [docs/](./docs/) – Additional reference documentation.
+

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,6 +13,7 @@ Memory Bank population and validation (August 2025)
 
 ### Recent Changes
 
+- Added `memory-bank/README.md` summarizing core files and linking subdirectories
 - Created `devcontainers-expert.chatmode.md` - comprehensive expert chat mode for all dev container scenarios
 - Updated `memory-bank/chatmodes/README.md` to include the new chat mode with description
 - Synthesized knowledge from all devcontainer documentation files for expert guidance
@@ -36,6 +37,7 @@ Memory Bank population and validation (August 2025)
 
 ### Code Changes
 
+- Added `memory-bank/README.md` summarizing core files and subdirectory links
 - Added `memory-bank/chatmodes/devcontainers-expert.chatmode.md` - comprehensive expert chat mode
 - Updated `memory-bank/chatmodes/README.md` to include the new chat mode
 - Previously: Added `scripts/build-ts-project.sh`, `Build TypeScript Project` task, and `build-ts-project.prompt.md`

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -33,6 +33,7 @@ This section provides a high-level overview of the project's current state, incl
 
 ### Major Milestones Achieved
 
+- 2025-08-05: Added Memory Bank README summarizing core files and linking subdirectories for easier navigation
 - 2025-08-04: Added TypeScript build task, script, and prompt following 1:1:1 protocol (enables future development workflows)
 - 2025-08-04: Created DevContainers Expert chat mode with comprehensive knowledge synthesis from 9 documentation files
 


### PR DESCRIPTION
## Summary
- add `memory-bank/README.md` that outlines core files and links to documentation subdirectories
- record the new overview in active context and progress logs

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68917f1c173083318b1d1ba9599e46fe