### PR TITLE
chore(memory-bank): add docs reference guide

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,6 +17,7 @@ Memory Bank population and validation (August 2025)
 - Updated `memory-bank/chatmodes/README.md` to include the new chat mode with description
 - Synthesized knowledge from all devcontainer documentation files for expert guidance
 - Internal documentation files added to `memory-bank/instructions/` and referenced in Memory Bank core files for improved cross-linking and agent discoverability.
+- Added `memory-bank/docs/README.md` summarizing documentation references for tasks and prompts
 
 ### Last Session Summary
 
@@ -25,6 +26,7 @@ Memory Bank population and validation (August 2025)
 - Followed Memory Bank protocol and chatmode creation guidelines strictly
 - Updated chatmodes documentation to maintain synchronization
 - Began referencing internal instructions documentation in all relevant Memory Bank files.
+- Created `memory-bank/docs/README.md` summarizing available documentation references for tasks and prompt creation
 
 ### Recent Decisions
 

--- a/memory-bank/docs/README.md
+++ b/memory-bank/docs/README.md
@@ -1,0 +1,25 @@
+# Memory Bank Documentation
+
+This directory collects reference materials for creating and maintaining tasks, prompts, and chat modes.
+
+## Available References
+
+- [tasks.md](./tasks.md) – Guides configuring VS Code tasks for running scripts and external tools.
+- [tasks-appendix.md](./tasks-appendix.md) – Provides the complete `tasks.json` schema for custom task definitions.
+- [task-provider.md](./task-provider.md) – Explains how extensions contribute task providers.
+- [docker-tasks-reference.md](./docker-tasks-reference.md) – Covers Docker build and run task customization.
+- [variables-reference.md](./variables-reference.md) – Lists predefined variables for use in task and launch configurations.
+- [chat-modes.md](./chat-modes.md) – Describes built-in and custom chat modes for guiding AI behavior.
+
+Additional resources are available in the [devcontainers/](./devcontainers) folder for containerized development.
+
+## Using These Documents
+
+These references support creating new tasks and their associated prompts:
+
+1. **Plan tasks** with guidance from `tasks.md` and `tasks-appendix.md`.
+2. **Leverage variables** from `variables-reference.md` to make tasks portable.
+3. **Document workflows** by pairing each task with a matching script and prompt, following the Memory Bank 1:1:1 pattern.
+4. **Design chat modes and prompts** using insights from `chat-modes.md` and related docs.
+
+Use this README as a starting point when exploring task or prompt creation resources within the Memory Bank.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -35,6 +35,7 @@ This section provides a high-level overview of the project's current state, incl
 
 - 2025-08-04: Added TypeScript build task, script, and prompt following 1:1:1 protocol (enables future development workflows)
 - 2025-08-04: Created DevContainers Expert chat mode with comprehensive knowledge synthesis from 9 documentation files
+- 2025-08-05: Added documentation index (`memory-bank/docs/README.md`) summarizing references for tasks and prompts
 
 ### Features Implemented
 


### PR DESCRIPTION
## Summary
- add README indexing documentation references for tasks, variables, and chat modes
- note new README in active context and progress logs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68917f1dcc648331a5acc45703b55329