### PR TITLE
chore(tasks): add placeholder initialization tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,26 +2,86 @@
   "tasks": [
     {
       "command": "bash ${workspaceFolder}/scripts/build-ts-project.sh",
-      "detail": "Builds the TypeScript project in the src folder using the build-ts-project.sh script.",
+      "detail": "See memory-bank/prompts/build-ts-project.prompt.md",
       "group": {
         "isDefault": false,
         "kind": "build"
       },
-      "label": "Build TypeScript Project",
+      "label": "build-ts-project.prompt.md",
       "type": "shell"
     },
     {
       "command": "bash ${workspaceFolder}/scripts/get-current-datetime.sh",
-      "detail": "Outputs the current local date/time for Québec City (America/Toronto timezone) using the related script.",
+      "detail": "See memory-bank/prompts/get-current-datetime.prompt.md",
       "group": {
         "isDefault": true,
         "kind": "build"
       },
-      "label": "Get Current Date/Time (Québec City Local)",
+      "label": "get-current-datetime.prompt.md",
       "presentation": {
         "panel": "shared",
         "reveal": "always"
       },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "command": "bash ${workspaceFolder}/scripts/update-memory-bank.sh",
+      "detail": "See memory-bank/prompts/update-memory-bank.prompt.md",
+      "group": {
+        "kind": "build"
+      },
+      "label": "update-memory-bank.prompt.md",
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "command": "bash ${workspaceFolder}/scripts/make-new-prompt.sh",
+      "detail": "See memory-bank/prompts/make-new-prompt.prompt.md",
+      "group": {
+        "kind": "build"
+      },
+      "label": "make-new-prompt.prompt.md",
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "command": "bash ${workspaceFolder}/scripts/make-new-instructions.sh",
+      "detail": "See memory-bank/prompts/make-new-instructions.prompt.md",
+      "group": {
+        "kind": "build"
+      },
+      "label": "make-new-instructions.prompt.md",
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "command": "bash ${workspaceFolder}/scripts/init-python.sh",
+      "detail": "See memory-bank/prompts/init-python.prompt.md",
+      "group": {
+        "kind": "build"
+      },
+      "label": "init-python.prompt.md",
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "command": "bash ${workspaceFolder}/scripts/init-web.sh",
+      "detail": "See memory-bank/prompts/init-web.prompt.md",
+      "group": {
+        "kind": "build"
+      },
+      "label": "init-web.prompt.md",
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "command": "bash ${workspaceFolder}/scripts/init-notebook.sh",
+      "detail": "See memory-bank/prompts/init-notebook.prompt.md",
+      "group": {
+        "kind": "build"
+      },
+      "label": "init-notebook.prompt.md",
       "problemMatcher": [],
       "type": "shell"
     }

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,6 +17,7 @@ Memory Bank population and validation (August 2025)
 - Updated `memory-bank/chatmodes/README.md` to include the new chat mode with description
 - Synthesized knowledge from all devcontainer documentation files for expert guidance
 - Internal documentation files added to `memory-bank/instructions/` and referenced in Memory Bank core files for improved cross-linking and agent discoverability.
+- Added placeholder scripts, prompts, and VS Code tasks for memory bank updates, prompt creation, instruction creation, and future Python/web/notebook initialization workflows
 
 ### Last Session Summary
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -35,6 +35,7 @@ This section provides a high-level overview of the project's current state, incl
 
 - 2025-08-04: Added TypeScript build task, script, and prompt following 1:1:1 protocol (enables future development workflows)
 - 2025-08-04: Created DevContainers Expert chat mode with comprehensive knowledge synthesis from 9 documentation files
+- 2025-08-05: Added placeholder tasks, scripts, and prompts for memory bank updates, prompt creation, instruction creation, and future initialization workflows
 
 ### Features Implemented
 
@@ -45,6 +46,7 @@ This section provides a high-level overview of the project's current state, incl
 
 - TypeScript build script (`scripts/build-ts-project.sh`) and VS Code task (`Build TypeScript Project`) in place
 - DevContainers Expert chat mode (`memory-bank/chatmodes/devcontainers-expert.chatmode.md`) with full knowledge base integration
+- Placeholder scripts and VS Code tasks established for memory bank updates, prompt creation, instruction creation, and future Python/web/notebook initialization
 
 ## Current Work
 

--- a/memory-bank/prompts/README.md
+++ b/memory-bank/prompts/README.md
@@ -50,6 +50,18 @@ This directory contains reusable prompt templates for common tasks, workflows, a
 
 **Purpose:** Ensures comprehensive memory bank updates, maintaining consistency across all files and providing complete context for AI agents. Includes review checklists and update workflows.
 
+### [init-python.prompt.md](../prompts/init-python.prompt.md)
+
+**Purpose:** Placeholder for initializing a Python project environment.
+
+### [init-web.prompt.md](../prompts/init-web.prompt.md)
+
+**Purpose:** Placeholder for initializing a web project environment.
+
+### [init-notebook.prompt.md](../prompts/init-notebook.prompt.md)
+
+**Purpose:** Placeholder for initializing a notebook environment.
+
 ---
 
 > **Note:** For detailed content, see each `.prompt.md` file directly. All prompts are cross-referenced and follow the Memory Bank protocol for persistent, high-quality documentation.

--- a/memory-bank/prompts/init-notebook.prompt.md
+++ b/memory-bank/prompts/init-notebook.prompt.md
@@ -1,0 +1,9 @@
+---
+mode: agent
+model: GPT-4.1
+tools: []
+description: Placeholder prompt for initializing a notebook environment.
+---
+# Initialize Notebook Environment
+
+This prompt is a placeholder for future notebook initialization instructions.

--- a/memory-bank/prompts/init-python.prompt.md
+++ b/memory-bank/prompts/init-python.prompt.md
@@ -1,0 +1,9 @@
+---
+mode: agent
+model: GPT-4.1
+tools: []
+description: Placeholder prompt for initializing a Python project.
+---
+# Initialize Python Project
+
+This prompt is a placeholder for future Python project initialization instructions.

--- a/memory-bank/prompts/init-web.prompt.md
+++ b/memory-bank/prompts/init-web.prompt.md
@@ -1,0 +1,9 @@
+---
+mode: agent
+model: GPT-4.1
+tools: []
+description: Placeholder prompt for initializing a web project.
+---
+# Initialize Web Project
+
+This prompt is a placeholder for future web project initialization instructions.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,3 +8,10 @@ All executable scripts must be referenced here with a description of their purpo
 - `memory-bank-validate.sh` - Validates memory bank completeness and consistency
 - `system-info.sh` - Displays basic system information and disk usage
 - `build-ts-project.sh` - Builds the TypeScript project in the src folder using tsc and src/tsconfig.json
+- `get-current-datetime.sh` - Outputs the current local date/time for Québec City
+- `update-memory-bank.sh` - Placeholder task for updating the memory bank
+- `make-new-prompt.sh` - Placeholder task for creating a new prompt
+- `make-new-instructions.sh` - Placeholder task for creating new instructions
+- `init-python.sh` - Placeholder task for initializing a Python project
+- `init-web.sh` - Placeholder task for initializing a web project
+- `init-notebook.sh` - Placeholder task for initializing a notebook environment

--- a/scripts/init-notebook.sh
+++ b/scripts/init-notebook.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "Placeholder: initialize notebook environment" 

--- a/scripts/init-python.sh
+++ b/scripts/init-python.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "Placeholder: initialize Python project" 

--- a/scripts/init-web.sh
+++ b/scripts/init-web.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "Placeholder: initialize web project" 

--- a/scripts/make-new-instructions.sh
+++ b/scripts/make-new-instructions.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "Placeholder: create new instructions" 

--- a/scripts/make-new-prompt.sh
+++ b/scripts/make-new-prompt.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "Placeholder: create new prompt" 

--- a/scripts/update-memory-bank.sh
+++ b/scripts/update-memory-bank.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "Placeholder: update memory bank" 


### PR DESCRIPTION
## Summary
- add placeholder VS Code tasks for memory bank updates, prompt creation, instruction creation, and future project initializations
- create matching scripts and prompt stubs for 1:1:1 mapping
- document new scripts and update memory bank

## Testing
- `bash scripts/memory-bank-validate.sh`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68917f1f514883318f25a183658e51f7