### PR TITLE
chore(tasks): add memory bank maintenance tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,7 @@
         "reveal": "always"
       },
       "problemMatcher": [],
-      "type": "shell",
+      "type": "shell"
     },
     {
       "command": "bash ${workspaceFolder}/scripts/memory-bank-init.sh",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -37,7 +37,7 @@
     },
     {
       "command": "bash ${workspaceFolder}/scripts/memory-bank-validate.sh",
-      "detail": "Checks memory bank completeness and consistency. See memory-bank/prompts/memory-update.prompt.md.",
+      "detail": "Checks memory bank completeness and consistency. See memory-bank/prompts/update-memory-bank.prompt.md.",
       "group": {
         "isDefault": false,
         "kind": "test"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
         "kind": "build"
       },
       "label": "Build TypeScript Project",
-      "type": "shell",
+      "type": "shell"
     },
     {
       "command": "bash ${workspaceFolder}/scripts/get-current-datetime.sh",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -43,7 +43,7 @@
         "kind": "test"
       },
       "label": "Validate Memory Bank",
-      "type": "shell",
+      "type": "shell"
     }
   ],
   "version": "2.0.0"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,17 +2,17 @@
   "tasks": [
     {
       "command": "bash ${workspaceFolder}/scripts/build-ts-project.sh",
-      "detail": "Builds the TypeScript project in the src folder using the build-ts-project.sh script.",
+      "detail": "Compiles the TypeScript project in src. See memory-bank/prompts/build-ts-project.prompt.md.",
       "group": {
         "isDefault": false,
         "kind": "build"
       },
       "label": "Build TypeScript Project",
-      "type": "shell"
+      "type": "shell",
     },
     {
       "command": "bash ${workspaceFolder}/scripts/get-current-datetime.sh",
-      "detail": "Outputs the current local date/time for Québec City (America/Toronto timezone) using the related script.",
+      "detail": "Outputs Québec City local date/time. See memory-bank/prompts/get-current-datetime.prompt.md.",
       "group": {
         "isDefault": true,
         "kind": "build"
@@ -23,7 +23,27 @@
         "reveal": "always"
       },
       "problemMatcher": [],
-      "type": "shell"
+      "type": "shell",
+    },
+    {
+      "command": "bash ${workspaceFolder}/scripts/memory-bank-init.sh",
+      "detail": "Initializes the memory bank structure. See memory-bank/prompts/initialization.prompt.md.",
+      "group": {
+        "isDefault": false,
+        "kind": "build"
+      },
+      "label": "Initialize Memory Bank",
+      "type": "shell",
+    },
+    {
+      "command": "bash ${workspaceFolder}/scripts/memory-bank-validate.sh",
+      "detail": "Checks memory bank completeness and consistency. See memory-bank/prompts/memory-update.prompt.md.",
+      "group": {
+        "isDefault": false,
+        "kind": "test"
+      },
+      "label": "Validate Memory Bank",
+      "type": "shell",
     }
   ],
   "version": "2.0.0"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,7 +33,7 @@
         "kind": "build"
       },
       "label": "Initialize Memory Bank",
-      "type": "shell",
+      "type": "shell"
     },
     {
       "command": "bash ${workspaceFolder}/scripts/memory-bank-validate.sh",

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -17,6 +17,7 @@ Memory Bank population and validation (August 2025)
 - Updated `memory-bank/chatmodes/README.md` to include the new chat mode with description
 - Synthesized knowledge from all devcontainer documentation files for expert guidance
 - Internal documentation files added to `memory-bank/instructions/` and referenced in Memory Bank core files for improved cross-linking and agent discoverability.
+- Added VS Code tasks for memory bank initialization and validation; updated prompts to reference them
 
 ### Last Session Summary
 
@@ -38,6 +39,7 @@ Memory Bank population and validation (August 2025)
 
 - Added `memory-bank/chatmodes/devcontainers-expert.chatmode.md` - comprehensive expert chat mode
 - Updated `memory-bank/chatmodes/README.md` to include the new chat mode
+- Added VS Code tasks for memory bank initialization and validation and linked related prompts
 - Previously: Added `scripts/build-ts-project.sh`, `Build TypeScript Project` task, and `build-ts-project.prompt.md`
 - Previously: Updated scripts/README.md and prompts/README.md
 - Referenced internal instructions documentation in Memory Bank core files.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -35,16 +35,19 @@ This section provides a high-level overview of the project's current state, incl
 
 - 2025-08-04: Added TypeScript build task, script, and prompt following 1:1:1 protocol (enables future development workflows)
 - 2025-08-04: Created DevContainers Expert chat mode with comprehensive knowledge synthesis from 9 documentation files
+- 2025-08-05: Added memory bank initialization and validation tasks with linked prompts to maintain 1:1:1 mapping
 
 ### Features Implemented
 
 - **TypeScript Build Task**: Fully implemented, documented, and protocol-compliant
 - **DevContainers Expert Chat Mode**: Comprehensive expert assistance for all dev container scenarios including setup, configuration, troubleshooting, and best practices
+- **Memory Bank Automation Tasks**: Initialization and validation tasks with prompt linkage for consistent maintenance
 
 ### Technical Infrastructure
 
 - TypeScript build script (`scripts/build-ts-project.sh`) and VS Code task (`Build TypeScript Project`) in place
 - DevContainers Expert chat mode (`memory-bank/chatmodes/devcontainers-expert.chatmode.md`) with full knowledge base integration
+- Memory bank initialization (`scripts/memory-bank-init.sh`) and validation (`scripts/memory-bank-validate.sh`) scripts with corresponding VS Code tasks
 
 ## Current Work
 

--- a/memory-bank/prompts/initialization.prompt.md
+++ b/memory-bank/prompts/initialization.prompt.md
@@ -6,6 +6,10 @@ This prompt template guides AI agents through the complete initialization of a n
 ## Template Usage
 Use this prompt when starting a new project or when memory bank needs complete regeneration.
 
+## Automation Task
+- **VS Code Task:** Initialize Memory Bank
+- **Script:** `scripts/memory-bank-init.sh`
+
 ## Prompt Template
 
 ```

--- a/memory-bank/prompts/memory-update.prompt.md
+++ b/memory-bank/prompts/memory-update.prompt.md
@@ -6,6 +6,10 @@ This prompt template ensures comprehensive memory bank updates that maintain con
 ## Template Usage
 Use this prompt when explicitly updating memory bank, after major changes, or when preparing for session handoffs.
 
+## Validation Task
+- **VS Code Task:** Validate Memory Bank
+- **Script:** `scripts/memory-bank-validate.sh`
+
 ## Prompt Template
 
 ```

--- a/memory-bank/prompts/update-memory-bank.prompt.md
+++ b/memory-bank/prompts/update-memory-bank.prompt.md
@@ -9,6 +9,10 @@ following the instructions in the [The Complete Guide to Cline Memory Bank](../i
 
 Shall you find any missing information, you shall add it to the memory bank files, following the instructions in the [Memory Bank Protocol](../instructions/memory-bank-core.instructions.md), and anything else that is required from you.
 
+## Validation Task
+- **VS Code Task:** Validate Memory Bank
+- **Script:** `scripts/memory-bank-validate.sh`
+
 ## Tools
 
 Run a natural language search for relevant code or documentation comments from the user's current workspace. Returns relevant code snippets from the user's current workspace if it is large, or the full contents of the workspace if it is small.


### PR DESCRIPTION
## Summary
- add Initialize and Validate Memory Bank tasks with prompt references
- link initialization and memory update prompts to their VS Code tasks
- document new maintenance tasks in active context and progress log

## Testing
- `bash scripts/memory-bank-validate.sh` *(fails: instructions/copilot.instructions.md missing)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68917f20bffc8331b8bb2ad513c0f668